### PR TITLE
Change queue generation functionality

### DIFF
--- a/datastorage/data/handler.go
+++ b/datastorage/data/handler.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"tradingplatform/datastorage/utils"
+	"tradingplatform/shared/communication/producer"
 	"tradingplatform/shared/entities"
 	"tradingplatform/shared/logging"
 	"tradingplatform/shared/types"
@@ -31,8 +32,8 @@ func HandleDataFetch[T any,
 	var queueID = ""
 
 	var messages []*entities.Message
+	queueID = producer.GenerateQueueID()
 	for _, entity := range result {
-		queueID = entity.GetFingerprint()
 		messages = append(messages,
 			entities.GenerateMessage(entity,
 				dtype,

--- a/sentimentanalyzer/handler/data.go
+++ b/sentimentanalyzer/handler/data.go
@@ -300,7 +300,7 @@ func HandleAnalysisNewsFromDB(ctx context.Context, req *requests.SentimentAnalys
 			return news[i].UpdatedAt < news[j].UpdatedAt
 		})
 
-		responseTopic := utils.NewDataTopic(types.SentimentAnalyzer, types.Internal, types.News, types.NewsWithSentiment, req.GetSymbol(), news[len(news)-1].Fingerprint, len(news)).Generate()
+		responseTopic := utils.NewDataTopic(types.SentimentAnalyzer, types.Internal, types.News, types.NewsWithSentiment, req.GetSymbol(), producer.GenerateQueueID(), len(news)).Generate()
 		handler, handlerResponse := producer.GetQueueHandler(responseTopic, req.NoConfirm)
 		if handlerResponse.Err != "" {
 			return handlerResponse

--- a/shared/communication/producer/queue_handler.go
+++ b/shared/communication/producer/queue_handler.go
@@ -3,6 +3,7 @@ package producer
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"sync"
 	"time"
 	"tradingplatform/shared/communication"
@@ -62,7 +63,7 @@ func handleQueue(handler *utils.Handler[[]*sharedent.Message], noConfirm bool) {
 	}
 	defer nc.Close()
 	msgs := <-handler.Ch
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*600)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
 
 	first := (*msgs)[0]
 	topic = first.Topic
@@ -91,4 +92,9 @@ func handleQueue(handler *utils.Handler[[]*sharedent.Message], noConfirm bool) {
 	delete(queues, topic)
 	queuesMutex.Unlock()
 	logging.Log().Debug().Str("topic", topic).Msg("queue handler stopped")
+}
+
+func GenerateQueueID() string {
+	return uuid.New().String()
+
 }


### PR DESCRIPTION
QueueID generation mechanism was changed to fix collision bug when the same data is requested.
The QueueID is now a random UUID instead of the fingerprint of the last entity sent. This way if there is a collision,
like when the end entity ends up being the same, data is still streamed to the client without errors.
